### PR TITLE
refactor(python): changed function and class imports to module imports

### DIFF
--- a/src/addTemplate.py
+++ b/src/addTemplate.py
@@ -8,7 +8,7 @@ import aqt
 from anki.lang import _
 from aqt import main, qt
 
-from .miutils import miAsk, miInfo
+from . import miutils
 
 if typing.TYPE_CHECKING:
     # TODO: @ColinKennedy - This line prevents a cyclic import. Fix later.
@@ -147,11 +147,13 @@ class TemplateEditor(qt.QDialog):
         newConfig = self._getConfig()
         tn = self._templateName.text()
         if tn == "":
-            miInfo("The export template must have a name.", level="wrn")
+            miutils.miInfo("The export template must have a name.", level="wrn")
             return
         curGroups = newConfig["ExportTemplates"]
         if self._new and tn in curGroups:
-            miInfo("A new export template must have a unique name.", level="wrn")
+            miutils.miInfo(
+                "A new export template must have a unique name.", level="wrn"
+            )
             return
         exportTemplate: typer.ExportTemplate = {
             "noteType": self._noteType.currentText(),

--- a/src/checkForThirtyTwo.py
+++ b/src/checkForThirtyTwo.py
@@ -1,20 +1,21 @@
-from anki.hooks import addHook
-from anki.utils import is_mac, is_win
+from anki import hooks, utils
 from aqt import qt
-from aqt.utils import openLink
+from aqt import utils as aqt_utils
 
-from .miutils import miAsk
+from . import miutils
 
 
 def _checkForThirtyTwo() -> None:
-    if is_win or is_mac:
+    if utils.is_win or utils.is_mac:
         qVer = qt.QT_VERSION_STR
         invalid = ["5.12.6", "5.9.7"]
         if qVer in invalid:
             msg = "You are on 32-bit Anki!\n32-bit Anki has known compatibility issues with Migaku addons.\n\nMigaku add-ons and Browser Extension integration WILL NOT WORK CORRECTLY.\n\nIf you're on a 64-bit system, please update to the 64-bit version of Anki."
-            if miAsk(msg, customText=["Download Now! 😄", "I like 32 bit. 🥺"]):
-                openLink("https://www.migaku.io/tools-guides/anki/guide#installation")
+            if miutils.miAsk(msg, customText=["Download Now! 😄", "I like 32 bit. 🥺"]):
+                aqt_utils.openLink(
+                    "https://www.migaku.io/tools-guides/anki/guide#installation"
+                )
 
 
 def initialize() -> None:
-    addHook("profileLoaded", _checkForThirtyTwo)
+    hooks.addHook("profileLoaded", _checkForThirtyTwo)

--- a/src/dictdb.py
+++ b/src/dictdb.py
@@ -10,10 +10,7 @@ import sqlite3
 import typing
 from collections import abc
 
-from aqt.utils import showInfo
-
 from . import typer
-from .miutils import miInfo
 
 addon_path = os.path.dirname(__file__)
 from aqt import mw

--- a/src/dictionaryManager.py
+++ b/src/dictionaryManager.py
@@ -16,9 +16,7 @@ from collections import abc
 import aqt
 from aqt import mw, qt
 
-from . import dictdb, typer
-from .dictionaryWebInstallWizard import DictionaryWebInstallWizard
-from .freqConjWebWindow import FreqConjWebWindow
+from . import dictdb, dictionaryWebInstallWizard, freqConjWebWindow, typer
 
 _DEFINITION_TABLE_SEPARATOR = ", "
 _NOT_SET_FREQUENCY = 999999  # NOTE: This means "not frequent or frequency is not known"
@@ -343,7 +341,7 @@ class DictionaryManagerWidget(qt.QWidget):
         return curr_item
 
     def _web_installer(self) -> None:
-        DictionaryWebInstallWizard.execute_modal()
+        dictionaryWebInstallWizard.DictionaryWebInstallWizard.execute_modal()
         self._reload_tree_widget()
 
     def _add_lang(self) -> None:
@@ -447,7 +445,9 @@ class DictionaryManagerWidget(qt.QWidget):
             return
         lang_name = lang_item.data(0, qt.Qt.ItemDataRole.UserRole + 0)
 
-        FreqConjWebWindow.execute_modal(lang_name, FreqConjWebWindow.Mode.Freq)
+        freqConjWebWindow.FreqConjWebWindow.execute_modal(
+            lang_name, freqConjWebWindow.FreqConjWebWindow.Mode.Freq
+        )
 
     def _set_conj_data(self) -> None:
         lang_name = self._get_current_lang_dict()[0]
@@ -482,7 +482,9 @@ class DictionaryManagerWidget(qt.QWidget):
             return
         lang_name = lang_item.data(0, qt.Qt.ItemDataRole.UserRole + 0)
 
-        FreqConjWebWindow.execute_modal(lang_name, FreqConjWebWindow.Mode.Conj)
+        freqConjWebWindow.FreqConjWebWindow.execute_modal(
+            lang_name, freqConjWebWindow.FreqConjWebWindow.Mode.Conj
+        )
 
     def _import_dict(self) -> None:
         lang_item = self._get_current_lang_item()
@@ -521,7 +523,7 @@ class DictionaryManagerWidget(qt.QWidget):
             return
         lang_name = lang_item.data(0, qt.Qt.ItemDataRole.UserRole + 0)
 
-        DictionaryWebInstallWizard.execute_modal(lang_name)
+        dictionaryWebInstallWizard.DictionaryWebInstallWizard.execute_modal(lang_name)
         self._reload_tree_widget()
 
     def _remove_dict(self) -> None:

--- a/src/dictionaryWebInstallWizard.py
+++ b/src/dictionaryWebInstallWizard.py
@@ -5,10 +5,10 @@ import os
 import typing
 
 import aqt
-from anki.httpclient import HttpClient
+from anki import httpclient
 from aqt import qt
+from PyQt6 import QtGui
 from PyQt6.QtCore import Qt
-from PyQt6.QtGui import QTextCursor
 
 from . import dictdb, migaku_wizard, typer, webConfig
 
@@ -397,7 +397,7 @@ class DictionaryInstallPage(migaku_wizard.MiWizardPage[DictionaryWebInstallWizar
         self.install_thread: typing.Optional[InstallThread] = None
 
     def _add_log(self, txt: str) -> None:
-        self.log_box.moveCursor(QTextCursor.MoveOperation.End)
+        self.log_box.moveCursor(QtGui.QTextCursor.MoveOperation.End)
 
         if not _verify(self.log_box.document()).isEmpty():
             self.log_box.insertPlainText("\n")
@@ -504,9 +504,9 @@ class InstallThread(qt.QThread):
         return url
 
     def run(self) -> None:
-        from .dictionaryManager import importDict
+        from . import dictionaryManager
 
-        client = HttpClient()
+        client = httpclient.HttpClient()
 
         num_dicts = 0
         num_installed = 0
@@ -599,7 +599,7 @@ class InstallThread(qt.QThread):
                     self.log_update.emit(" Importing...")
                     ddata = client.stream_content(dl_resp)
                     try:
-                        importDict(lname, io.BytesIO(ddata), dname)
+                        dictionaryManager.importDict(lname, io.BytesIO(ddata), dname)
                     except ValueError as e:
                         self.log_update.emit(" ERROR: %s" % str(e))
                 else:

--- a/src/forvodl.py
+++ b/src/forvodl.py
@@ -9,9 +9,7 @@ import typing
 import urllib
 
 import requests
-from aqt.qt import QObject, QRunnable, pyqtSignal
-from aqt.utils import showInfo
-from bs4 import BeautifulSoup
+from aqt import qt
 
 languages = {
     "German": "de",
@@ -88,15 +86,15 @@ languages = {
 }
 
 
-class ForvoSignals(QObject):
-    resultsFound = pyqtSignal(list)
-    noResults = pyqtSignal(str)
-    finished = pyqtSignal()
+class ForvoSignals(qt.QObject):
+    resultsFound = qt.pyqtSignal(list)
+    noResults = qt.pyqtSignal(str)
+    finished = qt.pyqtSignal()
 
 
-class Forvo(QRunnable):
-    resultsFound = pyqtSignal(list)
-    noResults = pyqtSignal(str)
+class Forvo(qt.QRunnable):
+    resultsFound = qt.pyqtSignal(list)
+    noResults = qt.pyqtSignal(str)
 
     def __init__(self, language: str) -> None:
         super().__init__()

--- a/src/freqConjWebWindow.py
+++ b/src/freqConjWebWindow.py
@@ -1,8 +1,8 @@
+import enum
 import os
 import typing
-from enum import Enum
 
-from anki.httpclient import HttpClient
+from anki import httpclient
 from aqt import qt
 
 from . import typer, webConfig
@@ -12,7 +12,7 @@ addon_path = os.path.dirname(__file__)
 
 class FreqConjWebWindow(qt.QDialog):
 
-    class Mode(Enum):
+    class Mode(enum.Enum):
         Freq = (0,)
         Conj = (1,)
 
@@ -92,7 +92,7 @@ class FreqConjWebWindow(qt.QDialog):
 
         url = idx.data(qt.Qt.ItemDataRole.UserRole)
 
-        client = HttpClient()
+        client = httpclient.HttpClient()
         resp = client.get(url)
 
         if resp.status_code != 200:

--- a/src/google_imager.py
+++ b/src/google_imager.py
@@ -1,6 +1,6 @@
 import time
 import typing
-from urllib.request import Request, urlopen
+from urllib import request
 
 import aqt
 from aqt import mw
@@ -32,13 +32,13 @@ def _download_image(
 ) -> typing.Union[str, typing.Literal[False]]:
     try:
         filename = str(time.time()).replace(".", "") + ".png"
-        req = Request(
+        req = request.Request(
             url,
             headers={
                 "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/35.0.1916.47 Safari/537.36"
             },
         )
-        file = urlopen(req).read()
+        file = request.urlopen(req).read()
         image = aqt.QImage()
         image.loadFromData(file)
         image = image.scaled(

--- a/src/googleimages.py
+++ b/src/googleimages.py
@@ -9,10 +9,9 @@ import time
 import typing
 import urllib
 
+import bs4
 import requests
-from aqt.qt import QObject, QRunnable, pyqtSignal
-from aqt.utils import showInfo
-from bs4 import BeautifulSoup
+from aqt import qt
 
 _COUNTRY_CODES = {
     "Afghanistan": "countryAF",
@@ -260,15 +259,15 @@ _COUNTRY_CODES = {
 }
 
 
-class _GoogleSignals(QObject):
-    resultsFound = pyqtSignal(list)
-    noResults = pyqtSignal(str)
-    finished = pyqtSignal()
+class _GoogleSignals(qt.QObject):
+    resultsFound = qt.pyqtSignal(list)
+    noResults = qt.pyqtSignal(str)
+    finished = qt.pyqtSignal()
 
 
-class Google(QRunnable):
+class Google(qt.QRunnable):
 
-    # finished = pyqtSignal()
+    # finished = qt.pyqtSignal()
 
     def __init__(self) -> None:
         super().__init__()
@@ -398,7 +397,7 @@ class Google(QRunnable):
                 return None
             results = self._getResultsFromRawHtml(html)
             if len(results) == 0:
-                soup = BeautifulSoup(html, "html.parser")
+                soup = bs4.BeautifulSoup(html, "html.parser")
                 elements = soup.select(".rg_meta.notranslate")
                 jsons = [json.loads(e.get_text()) for e in elements]
 

--- a/src/history.py
+++ b/src/history.py
@@ -7,11 +7,10 @@ import datetime
 import json
 import typing
 
-from anki.utils import is_lin, is_mac, is_win
+from anki import utils
 from aqt import qt
-from aqt.utils import askUser, showInfo
 
-from .miutils import miAsk, miInfo
+from . import miutils
 
 if typing.TYPE_CHECKING:
     from . import midict
@@ -163,7 +162,7 @@ class HistoryBrowser(qt.QWidget):
         return vbox
 
     def _deleteHistory(self) -> None:
-        if not miAsk(
+        if not miutils.miAsk(
             "Clearing your history cannot be undone. Would you like to proceed?", self
         ):
             return
@@ -198,7 +197,7 @@ class HistoryBrowser(qt.QWidget):
 
     def setColors(self) -> None:
         if self.dictInt.nightModeToggler.day:
-            if is_mac:
+            if utils.is_mac:
                 self.tableView.setStyleSheet(self.dictInt.getMacTableStyle())
             else:
                 self.tableView.setStyleSheet("")

--- a/src/keypress_tracker.py
+++ b/src/keypress_tracker.py
@@ -1,4 +1,4 @@
-from anki.utils import is_lin, is_win
+from anki import utils
 
 from . import threader
 
@@ -22,7 +22,7 @@ def capture_key(keyList: list[str]) -> None:
 
     thread = threader.get()
 
-    if is_win:
+    if utils.is_win:
         if (
             "Key.ctrl_l" in _CURRENTLY_PRESSED
             and "'c'" in _CURRENTLY_PRESSED
@@ -54,7 +54,7 @@ def capture_key(keyList: list[str]) -> None:
         ):
             thread.handleImageExport()
             clear()
-    elif is_lin:
+    elif utils.is_lin:
         if (
             "Key.ctrl" in _CURRENTLY_PRESSED
             and "'c'" in _CURRENTLY_PRESSED

--- a/src/miJapaneseHandler.py
+++ b/src/miJapaneseHandler.py
@@ -2,9 +2,8 @@
 
 import typing
 
-from anki.notes import Note
+from anki import notes
 from aqt import main
-from aqt.utils import showInfo
 
 
 class miJHandler:
@@ -31,7 +30,7 @@ class miJHandler:
 
         return activeNotes
 
-    def attemptGenerate(self, note: Note) -> Note:
+    def attemptGenerate(self, note: notes.Note) -> notes.Note:
         # TODO: @ColinKennedy - fetchParsedField doesn't exist. And the git
         # history says it never did. So this method can probably be removed.
         #
@@ -52,7 +51,7 @@ class miJHandler:
         return note
 
     def attemptFieldGenerate(
-        self, text: str, field: str, model: str, note: Note
+        self, text: str, field: str, model: str, note: notes.Note
     ) -> str:
         # TODO: @ColinKennedy - fetchParsedField doesn't exist. And the git
         # history says it never did. So this method can probably be removed.

--- a/src/migakuMessage.py
+++ b/src/migakuMessage.py
@@ -3,14 +3,11 @@
 import os
 import re
 import typing
-from os.path import basename, dirname, exists, join
 
 import aqt
 import requests as req
 from anki.hooks import addHook
-from aqt import mw, qt
-from aqt.utils import openLink
-from aqt.webview import AnkiWebView
+from aqt import mw, qt, utils, webview
 
 _MIGAKU_SHOULD_NOT_SHOW_MESSAGE = False
 T = typing.TypeVar("T")
@@ -22,10 +19,10 @@ class _Config(typing.TypedDict):
 
 def attemptOpenLink(cmd: str) -> None:
     if cmd.startswith("openLink:"):
-        openLink(cmd[9:])
+        utils.openLink(cmd[9:])
 
 
-addon_path = dirname(__file__)
+addon_path = os.path.dirname(__file__)
 
 
 def _verify(value: typing.Optional[T]) -> T:
@@ -88,12 +85,12 @@ def miMessage(text: str, parent: typing.Optional[qt.QWidget] = None) -> bool:
 
     parent = parent or aqt.mw.app.activeWindow() or aqt.mw
 
-    icon = qt.QIcon(join(addon_path, "icons", "migaku.png"))
+    icon = qt.QIcon(os.path.join(addon_path, "icons", "migaku.png"))
     mb = qt.QMessageBox(parent)
     mb.setWindowIcon(icon)
     mb.setWindowTitle(title)
     cb = qt.QCheckBox("Don't show me the welcome screen again.")
-    wv = AnkiWebView()
+    wv = webview.AnkiWebView()
     page = _verify(wv.page())
     page._bridge.onCmd = attemptOpenLink
     wv.setFixedSize(680, 450)

--- a/src/migaku_forvo.py
+++ b/src/migaku_forvo.py
@@ -6,10 +6,10 @@ from urllib.request import Request, urlopen
 
 from aqt import gui_hooks, mw
 
-from .forvodl import Forvo
+from . import forvodl
 
 _LOGGER = logging.getLogger(__name__)
-_INSTANCE: typing.Optional[Forvo] = None
+_INSTANCE: typing.Optional[forvodl.Forvo] = None
 
 
 def _initialize() -> None:
@@ -20,7 +20,7 @@ def _initialize() -> None:
     if not configuration:
         raise RuntimeError(f'Configuration "{__name__}" is not defined.')
 
-    _INSTANCE = Forvo(configuration["ForvoLanguage"])
+    _INSTANCE = forvodl.Forvo(configuration["ForvoLanguage"])
 
 
 def _download_audio(urls: list[tuple[str, str, str, str]], count: int) -> list[str]:
@@ -73,7 +73,7 @@ def export_audio(term: str, count: int, lang: str) -> str:
     if not _INSTANCE:
         _initialize()
 
-    _INSTANCE = typing.cast(Forvo, _INSTANCE)
+    _INSTANCE = typing.cast(forvodl.Forvo, _INSTANCE)
 
     audioSeparator = ""
     urls = _INSTANCE.search(term, lang)

--- a/src/migaku_search.py
+++ b/src/migaku_search.py
@@ -2,7 +2,7 @@ import re
 import typing
 
 import aqt
-from anki.utils import is_win
+from anki import utils
 from aqt import mw, qt
 
 from . import midict, migaku_dictionary, migaku_widget_global
@@ -46,7 +46,7 @@ def performColSearch(text: str) -> None:
     browser.onSearchActivated()
     browser.activateWindow()
 
-    if not is_win:
+    if not utils.is_win:
         browser.setWindowState(
             browser.windowState() & ~qt.Qt.WindowState.WindowMinimized
             | qt.Qt.WindowState.WindowActive

--- a/src/miutils.py
+++ b/src/miutils.py
@@ -6,7 +6,6 @@ from os.path import dirname, join
 
 import aqt
 from aqt import qt
-from aqt.webview import AnkiWebView
 
 T = typing.TypeVar("T")
 addon_path = dirname(__file__)

--- a/src/webConfig.py
+++ b/src/webConfig.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 import typing
 
-from anki.httpclient import HttpClient
+from anki import httpclient
 
 from . import typer
 
@@ -27,7 +27,7 @@ def download_index(
 
     index_url = server_url + "/index.json"
 
-    client = HttpClient()
+    client = httpclient.HttpClient()
     resp = client.get(index_url)
 
     if resp.status_code != 200:

--- a/src/welcomer.py
+++ b/src/welcomer.py
@@ -1,7 +1,7 @@
 import os
 import typing
 
-from anki.utils import is_mac
+from anki import utils
 
 _CURRENT_DIRECTORY = os.path.dirname(os.path.realpath(__file__))
 
@@ -20,7 +20,7 @@ def getMacWelcomeScreen() -> str:
         return fh.read()
 
 
-if is_mac:
+if utils.is_mac:
     welcomeScreen = getMacWelcomeScreen
 else:
     welcomeScreen = getWelcomeScreen


### PR DESCRIPTION
The class and function imports pollute module namespaces and makes code harder to know whether a called function is defined in the current file or imported from another file.

This PR changes the imports to (mostly) module imports to improve all of this.
